### PR TITLE
SF4 compatibility

### DIFF
--- a/DependencyInjection/AvooAchievementExtension.php
+++ b/DependencyInjection/AvooAchievementExtension.php
@@ -63,6 +63,12 @@ class AvooAchievementExtension extends Extension
 
                 $definition->addTag('avoo_achievement.achievement', array('type' => $category . '.' . $type));
 
+                /**
+                 * Set to be public, for Symfony 3.4+
+                 * @see: https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default
+                 */
+                $definition->setPublic(true);
+
                 $container->setDefinition(sprintf('avoo_achievement.achievement.%s.%s', $category, $type), $definition);
             }
         }

--- a/DependencyInjection/AvooAchievementExtension.php
+++ b/DependencyInjection/AvooAchievementExtension.php
@@ -2,7 +2,7 @@
 
 namespace Avoo\AchievementBundle\DependencyInjection;
 
-use Avoo\AchievementBundle\Listener\AchievementOptions;
+use Doctrine\ORM\EntityManager;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
@@ -43,7 +43,7 @@ class AvooAchievementExtension extends Extension
                 $definition->setClass($achievement['class']);
 
                 $definition->setArguments(array(
-                    'manager' => new Reference('doctrine.orm.default_entity_manager')
+                    EntityManager::class => new Reference('doctrine.orm.default_entity_manager')
                 ));
 
                 $options = new Definition('Avoo\AchievementBundle\Listener\AchievementOptions', array(array(

--- a/Listener/AchievementListener.php
+++ b/Listener/AchievementListener.php
@@ -28,22 +28,22 @@ abstract class AchievementListener implements AchievementListenerInterface
     /**
      * @var UserInterface|null $user
      */
-    private $user;
+    protected $user;
 
     /**
      * @var UserAchievementRepository $repository
      */
-    private $repository;
+    protected $repository;
 
     /**
      * @var EntityManager $manager
      */
-    private $manager;
+    protected $manager;
 
     /**
      * @var bool $isComplete
      */
-    private $isComplete = false;
+    protected $isComplete = false;
 
     /**
      * Construct


### PR DESCRIPTION
Fixing code to be compatible with Symfony 4:
* Set service has `public` for SF3.4+
* Fixing error: `method "Avoo\AchievementBundle\Listener\AchievementListener::__construct()" has no argument type-hinted as "manager".`