### PR TITLE
Fixing SF4.3+ deprecation notice for `TreeBuilder`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,8 +15,13 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('avoo_achievement');
+        $treeBuilder = new TreeBuilder('avoo_achievement');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('avoo_achievement');
+        }
 
         $this->addServicesSection($rootNode);
         $this->addAchievementsSection($rootNode);


### PR DESCRIPTION
Fixing Symfony 4.3+ about `Symfony\Component\Config\Definition\Builder\TreeBuilder` deprecation notice, using method `getRootNode()` instead of `root()` method.